### PR TITLE
Fix ImportError - No module named 'exceptions'

### DIFF
--- a/docs/views.py
+++ b/docs/views.py
@@ -9,7 +9,6 @@ from django.contrib.auth.views import login
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.utils.translation import ugettext as _
-from exceptions import ValueError
 
 
 def superuser_required(view_func):


### PR DESCRIPTION
Module exceptions is not neccessary import explicitly. In python3 import raise exception ImportError - No module named 'exceptions'.
