### PR TITLE
Fix RemovedInDjango19Warning - RedirectView.permanent

### DIFF
--- a/docs/urls.py
+++ b/docs/urls.py
@@ -2,6 +2,6 @@ from django.conf.urls import patterns, url
 from docs.views import DocsRootView, serve_docs
 
 urlpatterns = patterns('',
-                       url(r'^$', DocsRootView.as_view(), name='docs_root'),
+                       url(r'^$', DocsRootView.as_view(permanent=True), name='docs_root'),
                        url(r'^(?P<path>.*)$', serve_docs, name='docs_files'),
 )


### PR DESCRIPTION
Fix RemovedInDjango19Warning: Default value of 'RedirectView.permanent' will change from True to False in Django 1.9. Set an explicit value to silence this warning. url(r'^$', DocsRootView.as_view(), name='docs_root'),
