### PR TITLE
Support for Django 2.0

### DIFF
--- a/docs/views.py
+++ b/docs/views.py
@@ -1,5 +1,10 @@
 from django.views.generic import RedirectView
-from django.core.urlresolvers import reverse
+
+try:
+    from django.core.urlresolvers import reverse
+except ModuleNotFoundError:
+    from django.urls import reverse
+
 from django.views.static import serve
 from django.conf import settings
 from django.contrib.auth.decorators import login_required


### PR DESCRIPTION
Per the release notes at https://docs.djangoproject.com/en/2.0/releases/2.0/#deprecated-features-2-0, the django.core.urlresolvers module is removed in favor of its new location, django.urls.

This change fixes an import error that occurs in Django 2, but should still work in django<2 projects