### PR TITLE
Namespace added to viewname on reverse function on DocsRootView

### DIFF
--- a/docs/views.py
+++ b/docs/views.py
@@ -93,8 +93,6 @@ def serve_docs(request, path, **kwargs):
 
 class DocsRootView(RedirectView):
     def get_redirect_url(self, **kwargs):
-        viewname = 'docs_files'
-        if self.request.resolver_match.namespace:
-            viewname = '%s:docs_files' % self.request.resolver_match.namespace
-        return reverse(viewname, kwargs={'path': 'index.html'})
+        view_name = ':'.join(filter(None, [self.request.resolver_match.namespace, 'docs_files']))
+        return reverse(view_name, kwargs={'path': 'index.html'})
 

--- a/docs/views.py
+++ b/docs/views.py
@@ -93,5 +93,8 @@ def serve_docs(request, path, **kwargs):
 
 class DocsRootView(RedirectView):
     def get_redirect_url(self, **kwargs):
-        return reverse('docs_files', kwargs={'path': 'index.html'})
+        viewname = 'docs_files'
+        if self.request.resolver_match.namespace:
+            viewname = '%s:docs_files' % self.request.resolver_match.namespace
+        return reverse(viewname, kwargs={'path': 'index.html'})
 


### PR DESCRIPTION
Using namespace while registering the `url(r'^docs/', include('docs.urls', namespace='mydocs')),` breaks the `DocsRootView` raising the `NoReverseMatch` exception
```Reverse for 'docs_files' not found. 'docs_files' is not a valid view function or pattern name.```

Namespace can be appended to the viewname before feeding to `reverse`