### PR TITLE
views.py

### DIFF
--- a/docs/views.py
+++ b/docs/views.py
@@ -10,7 +10,12 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from functools import wraps
 from django.contrib.admin.forms import AdminAuthenticationForm
-from django.contrib.auth.views import login
+
+try:
+    from django.contrib.auth.views import login
+except ImportError:
+    from django.contrib.auth.views import LoginView
+
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.utils.translation import ugettext as _


### PR DESCRIPTION
Django release 2.1 removed feature contrib.auth.views.login(). This view is imported in views.py. The issue is address with a try block with the new pattern.