### PR TITLE
Update superuser_required Decorator Returned Function

### DIFF
--- a/docs/views.py
+++ b/docs/views.py
@@ -36,7 +36,7 @@ def superuser_required(view_func):
                 'app_path': request.get_full_path()
                 }
             }
-        return LoginView(request, **defaults)
+        return LoginView.as_view()(request, **defaults)
     return _checklogin
 
 


### PR DESCRIPTION
Using the [`superuser_required` decorator](https://github.com/littlepea/django-docs/blob/master/docs/views.py#L18), we noticed that non-superusers would get an error when trying to view the docs URLs:
```*** TypeError: __init__() takes 1 positional argument but 2 were given```.

This appears to be because the `LoginView` is being instantiated with multiple arguments, which it does not support. I think the fix would be to return the `LoginView` class's `as_view()` method, with the `request` and `defaults` arguments passed into it, which would return a function the same way that this decorator used to, before the change in https://github.com/littlepea/django-docs/commit/ba6ba8b1f6e67d0aba66d7d22503933ee82c0543.