### PR TITLE
Replace deprecated django.conf.urls.url by django.conf.urls.re_path

### DIFF
--- a/docs/tests/urls.py
+++ b/docs/tests/urls.py
@@ -4,9 +4,9 @@ As you know, every app must be hooked into yout main ``urls.py`` so that
 you can actually reach the app's views (provided it has any views, of course).
 
 """
-from django.conf.urls import include, url
+from django.conf.urls import include, re_path
 
 
 urlpatterns = [
-    url(r'^', include('docs.urls')),
+    re_path(r'^', include('docs.urls')),
 ]

--- a/docs/urls.py
+++ b/docs/urls.py
@@ -1,13 +1,13 @@
-from django.conf.urls import url
+from django.conf.urls import re_path
 from docs.views import DocsRootView, serve_docs, DOCS_DIRHTML
 
 urlpatterns = []
 
 if not DOCS_DIRHTML:
     urlpatterns += [
-        url(r'^$', DocsRootView.as_view(permanent=True), name='docs_root'),
+        re_path(r'^$', DocsRootView.as_view(permanent=True), name='docs_root'),
     ]
 
 urlpatterns += [
-    url(r"^(?P<path>.*)$", serve_docs, name="docs_files"),
+    re_path(r"^(?P<path>.*)$", serve_docs, name="docs_files"),
 ]


### PR DESCRIPTION
Fix #33.