### PR TITLE
Issue #36 solved

### DIFF
--- a/docs/views.py
+++ b/docs/views.py
@@ -1,3 +1,4 @@
+import django
 from os.path import join
 from django.http.response import Http404
 from django.views.generic import RedirectView
@@ -14,7 +15,10 @@ from functools import wraps
 from django.contrib.admin.forms import AdminAuthenticationForm
 from django.contrib.auth.views import LoginView
 from django.contrib.admin.views.decorators import staff_member_required
-from django.utils.translation import ugettext as _
+if float(django.get_version())>=3:
+    from django.utils.translation import gettext as _
+else:
+    from django.utils.translation import ugettext as _
 
 
 def superuser_required(view_func):


### PR DESCRIPTION
Error from the 17th line of views.py:
`ImportError: cannot import name 'ugettext' from 'django.utils.translation'`

The mentioned error appears when running python3.10 and Django4.0.

17th line of views.py:
from django.utils.translation import ugettext as _

As 'ugettext_lazy' has been deprecated for django 3+, it is possible to use 'gettext_lazy' instead without 'u'.

An 'if' was added to check the Django version and use the correct function preserving the compatibility for previous versions of django-docs.